### PR TITLE
update cmake_minimum_required

### DIFF
--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,7 +1,7 @@
 #
 # Format and verify formatting using clang-format
 #
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 2.8.12)
 
 include(FindPackageHandleStandardArgs)
 

--- a/src/third_party/sparsehash/CMakeLists.txt
+++ b/src/third_party/sparsehash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 2.8.12)
 
 include(CheckCXXSourceCompiles)
 include(CheckFunctionExists)


### PR DESCRIPTION
CMake versions prior VERSION 2.8.12 are not supported in CMake 3.19+

