### PR TITLE
Suppress usage of uninitialized memory

### DIFF
--- a/src/aligned_storage.hpp
+++ b/src/aligned_storage.hpp
@@ -37,17 +37,17 @@ namespace datastax { namespace internal {
 // constructor.
 
 template <size_t N, size_t A>
-class AlignedStorage;
+__attribute__((__no_sanitize__("memory"))) class AlignedStorage;
 
-#define ALIGNED_STORAGE(Alignment)                \
-  template <size_t N>                             \
-  class AlignedStorage<N, Alignment> {            \
-  public:                                         \
-    void* address() { return data_; }             \
-    const void* address() const { return data_; } \
-                                                  \
-  private:                                        \
-    ALIGN_AS(Alignment) char data_[N];            \
+#define ALIGNED_STORAGE(Alignment)                                                \
+  template <size_t N>                                                             \
+  __attribute__((__no_sanitize__("memory"))) class AlignedStorage<N, Alignment> { \
+  public:                                                                         \
+    void* address() { return data_; }                                             \
+    const void* address() const { return data_; }                                 \
+                                                                                  \
+  private:                                                                        \
+    ALIGN_AS(Alignment) char data_[N];                                            \
   }
 
 ALIGNED_STORAGE(1);


### PR DESCRIPTION
```c++
==7==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x462d2ff0 in datastax::internal::SharedRefPtr<datastax::internal::core::DataType const>::~SharedRefPtr() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:91:9
    #1 0x462d2ff0 in datastax::internal::core::ColumnDefinition::~ColumnDefinition() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/result_metadata.hpp:32:8
    #2 0x462d2ff0 in datastax::internal::FixedAllocator<datastax::internal::core::ColumnDefinition, 16ul>::destroy(datastax::internal::core::ColumnDefinition*) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/fixed_allocator.hpp:99:33
    #3 0x462d2ff0 in void std::__1::allocator_traits<datastax::internal::FixedAllocator<datastax::internal::core::ColumnDefinition, 16ul> >::__destroy<datastax::internal::core::ColumnDefinition>(std::__1::integral_constant<bool, true>, datastax::internal::FixedAllocator<datastax::internal::core::ColumnDefinition, 16ul>&, datastax::internal::core::ColumnDefinition*) /home/jakalletti/ClickHouse/ClickHouse/contrib/libcxx/include/__memory/allocator_traits.h:539:21
    #4 0x462d2ff0 in void std::__1::allocator_traits<datastax::internal::FixedAllocator<datastax::internal::core::ColumnDefinition, 16ul> >::destroy<datastax::internal::core::ColumnDefinition>(datastax::internal::FixedAllocator<datastax::internal::core::ColumnDefinition, 16ul>&, datastax::internal::core::ColumnDefinition*) /home/jakalletti/ClickHouse/ClickHouse/contrib/libcxx/include/__memory/allocator_traits.h:487:14
    #5 0x462d2ff0 in std::__1::__vector_base<datastax::internal::core::ColumnDefinition, datastax::internal::FixedAllocator<datastax::internal::core::ColumnDefinition, 16ul> >::__destruct_at_end(datastax::internal::core::ColumnDefinition*) /home/jakalletti/ClickHouse/ClickHouse/contrib/libcxx/include/vector:428:9
    #6 0x462d2ff0 in std::__1::__vector_base<datastax::internal::core::ColumnDefinition, datastax::internal::FixedAllocator<datastax::internal::core::ColumnDefinition, 16ul> >::clear() /home/jakalletti/ClickHouse/ClickHouse/contrib/libcxx/include/vector:371:29
    #7 0x462d2ff0 in std::__1::__vector_base<datastax::internal::core::ColumnDefinition, datastax::internal::FixedAllocator<datastax::internal::core::ColumnDefinition, 16ul> >::~__vector_base() /home/jakalletti/ClickHouse/ClickHouse/contrib/libcxx/include/vector:465:9
    #8 0x462fd61f in std::__1::vector<datastax::internal::core::ColumnDefinition, datastax::internal::FixedAllocator<datastax::internal::core::ColumnDefinition, 16ul> >::~vector() /home/jakalletti/ClickHouse/ClickHouse/contrib/libcxx/include/vector:557:5
    #9 0x462fd61f in datastax::internal::SmallVector<datastax::internal::core::ColumnDefinition, 16ul>::~SmallVector() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/small_vector.hpp:31:7
    #10 0x462fd61f in datastax::internal::core::CaseInsensitiveHashTable<datastax::internal::core::ColumnDefinition>::~CaseInsensitiveHashTable() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/hash_table.hpp:49:7
    #11 0x462fd61f in datastax::internal::core::ResultMetadata::~ResultMetadata() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/result_metadata.hpp:39:7
    #12 0x462fd61f in datastax::internal::RefCounted<datastax::internal::core::ResultMetadata>::dec_ref() const /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:49:7
    #13 0x462f6c94 in datastax::internal::SharedRefPtr<datastax::internal::core::ResultMetadata>::~SharedRefPtr() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:92:13
    #14 0x462f6c94 in datastax::internal::core::ResultResponse::~ResultResponse() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/result_response.hpp:33:7
    #15 0x462f6dcc in datastax::internal::core::ResultResponse::~ResultResponse() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/result_response.hpp:33:7
    #16 0x46350f8d in datastax::internal::RefCounted<datastax::internal::core::Response>::dec_ref() const /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:49:7
    #17 0x46350f8d in datastax::internal::SharedRefPtr<datastax::internal::core::Response>::~SharedRefPtr() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:92:13
    #18 0x46350f8d in datastax::internal::core::ResponseMessage::~ResponseMessage() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/response.hpp:78:7
    #19 0x46350f8d in datastax::internal::DefaultDeleter<datastax::internal::core::ResponseMessage>::operator()(datastax::internal::core::ResponseMessage*) const /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/scoped_ptr.hpp:29:35
    #20 0x46350f8d in datastax::internal::ScopedPtr<datastax::internal::core::ResponseMessage, datastax::internal::DefaultDeleter<datastax::internal::core::ResponseMessage> >::~ScopedPtr() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/scoped_ptr.hpp:41:18
    #21 0x46350f8d in datastax::internal::core::Connection::on_read(char const*, unsigned long) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/connection.cpp:296:5
    #22 0x4634f171 in datastax::internal::core::ConnectionHandler::on_read(datastax::internal::core::Socket*, long, uv_buf_t const*) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/connection.cpp:75:16
    #23 0x465209bd in datastax::internal::core::Socket::handle_read(long, uv_buf_t const*) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/socket.cpp:368:13
    #24 0x465209bd in datastax::internal::core::Socket::on_read(uv_stream_s*, long, uv_buf_t const*) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/socket.cpp:358:11
    #25 0x467596f9 in uv__read /home/jakalletti/ClickHouse/ClickHouse/contrib/libuv/src/unix/stream.c:1243:7
    #26 0x467596f9 in uv__stream_io /home/jakalletti/ClickHouse/ClickHouse/contrib/libuv/src/unix/stream.c:1310:5
    #27 0x46774f85 in uv__io_poll /home/jakalletti/ClickHouse/ClickHouse/contrib/libuv/src/unix/linux-core.c:442:11
    #28 0x467147fa in uv_run /home/jakalletti/ClickHouse/ClickHouse/contrib/libuv/src/unix/core.c:375:5
    #29 0x463c1a56 in datastax::internal::core::EventLoop::handle_run() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/event_loop.cpp:168:3
    #30 0x463c1a56 in datastax::internal::core::EventLoop::internal_on_run(void*) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/event_loop.cpp:163:11
    #31 0x7f7cb2696608 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x9608)
    #32 0x7f7cb25bd292 in clone (/lib/x86_64-linux-gnu/libc.so.6+0x122292)

  Memory was marked as uninitialized
    #0 0x95c2aee in __sanitizer_dtor_callback (/usr/bin/clickhouse+0x95c2aee)
    #1 0x462fd5fd in datastax::internal::SmallVector<datastax::internal::core::ColumnDefinition, 16ul>::~SmallVector() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/small_vector.hpp:31:7
    #2 0x462fd5fd in datastax::internal::core::CaseInsensitiveHashTable<datastax::internal::core::ColumnDefinition>::~CaseInsensitiveHashTable() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/hash_table.hpp:49:7
    #3 0x462fd5fd in datastax::internal::core::ResultMetadata::~ResultMetadata() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/result_metadata.hpp:39:7
    #4 0x462fd5fd in datastax::internal::RefCounted<datastax::internal::core::ResultMetadata>::dec_ref() const /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:49:7
    #5 0x462f6c94 in datastax::internal::SharedRefPtr<datastax::internal::core::ResultMetadata>::~SharedRefPtr() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:92:13
    #6 0x462f6c94 in datastax::internal::core::ResultResponse::~ResultResponse() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/result_response.hpp:33:7
    #7 0x462f6dcc in datastax::internal::core::ResultResponse::~ResultResponse() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/result_response.hpp:33:7
    #8 0x46350f8d in datastax::internal::RefCounted<datastax::internal::core::Response>::dec_ref() const /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:49:7
    #9 0x46350f8d in datastax::internal::SharedRefPtr<datastax::internal::core::Response>::~SharedRefPtr() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:92:13
    #10 0x46350f8d in datastax::internal::core::ResponseMessage::~ResponseMessage() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/response.hpp:78:7
    #11 0x46350f8d in datastax::internal::DefaultDeleter<datastax::internal::core::ResponseMessage>::operator()(datastax::internal::core::ResponseMessage*) const /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/scoped_ptr.hpp:29:35
    #12 0x46350f8d in datastax::internal::ScopedPtr<datastax::internal::core::ResponseMessage, datastax::internal::DefaultDeleter<datastax::internal::core::ResponseMessage> >::~ScopedPtr() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/scoped_ptr.hpp:41:18
    #13 0x46350f8d in datastax::internal::core::Connection::on_read(char const*, unsigned long) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/connection.cpp:296:5
    #14 0x4634f171 in datastax::internal::core::ConnectionHandler::on_read(datastax::internal::core::Socket*, long, uv_buf_t const*) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/connection.cpp:75:16
    #15 0x465209bd in datastax::internal::core::Socket::handle_read(long, uv_buf_t const*) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/socket.cpp:368:13
    #16 0x465209bd in datastax::internal::core::Socket::on_read(uv_stream_s*, long, uv_buf_t const*) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/socket.cpp:358:11
    #17 0x467596f9 in uv__read /home/jakalletti/ClickHouse/ClickHouse/contrib/libuv/src/unix/stream.c:1243:7
    #18 0x467596f9 in uv__stream_io /home/jakalletti/ClickHouse/ClickHouse/contrib/libuv/src/unix/stream.c:1310:5
    #19 0x46774f85 in uv__io_poll /home/jakalletti/ClickHouse/ClickHouse/contrib/libuv/src/unix/linux-core.c:442:11
    #20 0x467147fa in uv_run /home/jakalletti/ClickHouse/ClickHouse/contrib/libuv/src/unix/core.c:375:5
    #21 0x463c1a56 in datastax::internal::core::EventLoop::handle_run() /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/event_loop.cpp:168:3
    #22 0x463c1a56 in datastax::internal::core::EventLoop::internal_on_run(void*) /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/event_loop.cpp:163:11
    #23 0x7f7cb2696608 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x9608)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/jakalletti/ClickHouse/ClickHouse/contrib/cassandra/src/ref_counted.hpp:91:9 in datastax::internal::SharedRefPtr<datastax::internal::core::DataType const>::~SharedRefPtr()

```